### PR TITLE
refactor: unify auth responses and route error UI

### DIFF
--- a/app/(auth)/error.tsx
+++ b/app/(auth)/error.tsx
@@ -1,8 +1,6 @@
 "use client";
 
-import { useEffect } from "react";
-
-import { Button } from "@/components/shared/ui";
+import { RouteErrorPanel } from "@/components/shared/ui";
 
 export default function AuthError({
   error,
@@ -11,23 +9,14 @@ export default function AuthError({
   error: Error & { digest?: string };
   reset: () => void;
 }) {
-  useEffect(() => {
-    console.error(error);
-  }, [error]);
-
   return (
-    <div className="cc-shell flex min-h-screen items-center justify-center px-6">
-      <div className="w-full max-w-lg rounded-[2rem] border border-border bg-white p-10 shadow-[var(--cc-shadow-soft)]">
-        <h1 className="text-3xl font-black tracking-[-0.05em] text-foreground">
-          인증 화면 오류
-        </h1>
-        <p className="mt-3 text-sm leading-6 text-text-secondary">
-          잠시 후 다시 시도해 주세요.
-        </p>
-        <Button className="mt-8" onClick={reset}>
-          다시 시도
-        </Button>
-      </div>
-    </div>
+    <RouteErrorPanel
+      error={error}
+      reset={reset}
+      title="인증 화면 오류"
+      description="잠시 후 다시 시도해 주세요."
+      wrapperClassName="cc-shell flex min-h-screen items-center justify-center px-6"
+      panelClassName="w-full max-w-lg"
+    />
   );
 }

--- a/app/(store)/error.tsx
+++ b/app/(store)/error.tsx
@@ -1,8 +1,6 @@
 "use client";
 
-import { useEffect } from "react";
-
-import { Button } from "@/components/shared/ui";
+import { RouteErrorPanel } from "@/components/shared/ui";
 
 export default function StoreError({
   error,
@@ -11,26 +9,14 @@ export default function StoreError({
   error: Error & { digest?: string };
   reset: () => void;
 }) {
-  useEffect(() => {
-    console.error(error);
-  }, [error]);
-
   return (
-    <div className="cc-grid py-16">
-      <div className="rounded-[2rem] border border-border bg-white p-10 shadow-[var(--cc-shadow-soft)]">
-        <p className="text-sm font-semibold uppercase tracking-[0.24em] text-brand-primary">
-          오류 발생
-        </p>
-        <h1 className="mt-4 text-3xl font-black tracking-[-0.05em] text-foreground">
-          화면을 불러오지 못했습니다
-        </h1>
-        <p className="mt-3 text-sm leading-6 text-text-secondary">
-          잠시 후 다시 시도해 주세요.
-        </p>
-        <Button className="mt-8" onClick={reset}>
-          다시 시도
-        </Button>
-      </div>
-    </div>
+    <RouteErrorPanel
+      error={error}
+      reset={reset}
+      eyebrow="오류 발생"
+      title="화면을 불러오지 못했습니다"
+      description="잠시 후 다시 시도해 주세요."
+      wrapperClassName="cc-grid py-16"
+    />
   );
 }

--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -1,10 +1,8 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 
-import type { User } from "@/lib/auth";
 import { requestBackend } from "@/lib/shared/api";
-import { getSessionCookieOptions } from "@/lib/auth/server";
+import { createSessionAuthResponse } from "@/lib/auth/server";
 import { jsonError } from "@/lib/shared/api/server";
-import type { ApiResponse } from "@/lib/shared/types";
 
 export async function POST(request: NextRequest) {
   try {
@@ -15,24 +13,11 @@ export async function POST(request: NextRequest) {
       fallbackMessage: "로그인에 실패했습니다.",
     });
 
-    const response = NextResponse.json((payload ?? {
-      success: false,
-      error: { message: "로그인에 실패했습니다.", statusCode: status },
-    }) as ApiResponse<unknown>, { status });
-
-    if (payload && "success" in payload && payload.success) {
-      const data = payload.data as {
-        user: User;
-        accessToken: string;
-        expiresIn: number;
-      };
-      response.cookies.set({
-        ...getSessionCookieOptions(data.expiresIn),
-        value: data.accessToken,
-      });
-    }
-
-    return response;
+    return createSessionAuthResponse({
+      status,
+      payload,
+      fallbackMessage: "로그인에 실패했습니다.",
+    });
   } catch {
     return jsonError("로그인 요청을 처리할 수 없습니다.");
   }

--- a/app/api/auth/logout/route.ts
+++ b/app/api/auth/logout/route.ts
@@ -1,8 +1,10 @@
-import { NextResponse } from "next/server";
-
 import { requestBackend } from "@/lib/shared/api";
 import { env } from "@/lib/shared/env";
-import { getSessionTokenFromCookies, jsonError } from "@/lib/shared/api/server";
+import {
+  getSessionTokenFromCookies,
+  jsonApiResponse,
+  jsonError,
+} from "@/lib/shared/api/server";
 import type { ApiResponse } from "@/lib/shared/types";
 
 export async function POST() {
@@ -20,8 +22,10 @@ export async function POST() {
     });
     const responseStatus =
       status === 204 && payload && "success" in payload && payload.success ? 200 : status;
-    const response = NextResponse.json(payload as ApiResponse<unknown>, {
+    const response = jsonApiResponse({
       status: responseStatus,
+      payload,
+      fallbackMessage: "로그아웃에 실패했습니다.",
     });
     response.cookies.delete(env.sessionCookieName);
     return response;

--- a/app/api/auth/register/route.ts
+++ b/app/api/auth/register/route.ts
@@ -1,10 +1,8 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 
-import type { User } from "@/lib/auth";
 import { requestBackend } from "@/lib/shared/api";
-import { getSessionCookieOptions } from "@/lib/auth/server";
+import { createSessionAuthResponse } from "@/lib/auth/server";
 import { jsonError } from "@/lib/shared/api/server";
-import type { ApiResponse } from "@/lib/shared/types";
 
 export async function POST(request: NextRequest) {
   try {
@@ -15,24 +13,11 @@ export async function POST(request: NextRequest) {
       fallbackMessage: "회원가입에 실패했습니다.",
     });
 
-    const response = NextResponse.json((payload ?? {
-      success: false,
-      error: { message: "회원가입에 실패했습니다.", statusCode: status },
-    }) as ApiResponse<unknown>, { status });
-
-    if (payload && "success" in payload && payload.success) {
-      const data = payload.data as {
-        user: User;
-        accessToken: string;
-        expiresIn: number;
-      };
-      response.cookies.set({
-        ...getSessionCookieOptions(data.expiresIn),
-        value: data.accessToken,
-      });
-    }
-
-    return response;
+    return createSessionAuthResponse({
+      status,
+      payload,
+      fallbackMessage: "회원가입에 실패했습니다.",
+    });
   } catch {
     return jsonError("회원가입 요청을 처리할 수 없습니다.");
   }

--- a/components/shared/ui/index.ts
+++ b/components/shared/ui/index.ts
@@ -3,5 +3,6 @@ export * from "./button";
 export * from "./card";
 export * from "./empty-state";
 export * from "./input";
+export * from "./route-error-panel";
 export * from "./textarea";
 export * from "./toggle";

--- a/components/shared/ui/route-error-panel.tsx
+++ b/components/shared/ui/route-error-panel.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useEffect } from "react";
+
+import { cn } from "@/lib/shared/utils";
+
+import { Button } from "./button";
+
+type RouteErrorPanelProps = {
+  error: Error & { digest?: string };
+  reset: () => void;
+  title: string;
+  description: string;
+  eyebrow?: string;
+  actionLabel?: string;
+  wrapperClassName?: string;
+  panelClassName?: string;
+};
+
+export function RouteErrorPanel({
+  error,
+  reset,
+  title,
+  description,
+  eyebrow,
+  actionLabel = "다시 시도",
+  wrapperClassName,
+  panelClassName,
+}: RouteErrorPanelProps) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className={wrapperClassName}>
+      <div
+        className={cn(
+          "rounded-[2rem] border border-border bg-white p-10 shadow-[var(--cc-shadow-soft)]",
+          panelClassName,
+        )}
+      >
+        {eyebrow ? (
+          <p className="text-sm font-semibold uppercase tracking-[0.24em] text-brand-primary">
+            {eyebrow}
+          </p>
+        ) : null}
+        <h1 className="mt-4 text-3xl font-black tracking-[-0.05em] text-foreground">
+          {title}
+        </h1>
+        <p className="mt-3 text-sm leading-6 text-text-secondary">{description}</p>
+        <Button className="mt-8" onClick={reset}>
+          {actionLabel}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/lib/auth/server/index.ts
+++ b/lib/auth/server/index.ts
@@ -1,2 +1,3 @@
 export * from "..";
+export * from "./response";
 export * from "./session";

--- a/lib/auth/server/response.ts
+++ b/lib/auth/server/response.ts
@@ -1,0 +1,60 @@
+import type { User } from "@/lib/auth";
+import { jsonApiResponse } from "@/lib/shared/api/server";
+import type { ApiResponse } from "@/lib/shared/types";
+
+import { getSessionCookieOptions } from "./session";
+
+type AuthSessionData = {
+  user: User;
+  accessToken: string;
+  expiresIn: number;
+};
+
+type AuthSessionSuccessResponse = Extract<
+  ApiResponse<AuthSessionData>,
+  { success: true }
+>;
+
+function hasSessionCookieData(
+  payload: ApiResponse<unknown> | null | undefined,
+): payload is AuthSessionSuccessResponse {
+  if (!payload || !payload.success) {
+    return false;
+  }
+
+  const { data } = payload;
+
+  return (
+    typeof data === "object" &&
+    data !== null &&
+    "accessToken" in data &&
+    typeof data.accessToken === "string" &&
+    "expiresIn" in data &&
+    typeof data.expiresIn === "number"
+  );
+}
+
+export function createSessionAuthResponse({
+  status,
+  payload,
+  fallbackMessage,
+}: {
+  status: number;
+  payload?: ApiResponse<unknown> | null;
+  fallbackMessage: string;
+}) {
+  const response = jsonApiResponse({
+    status,
+    payload,
+    fallbackMessage,
+  });
+
+  if (hasSessionCookieData(payload)) {
+    response.cookies.set({
+      ...getSessionCookieOptions(payload.data.expiresIn),
+      value: payload.data.accessToken,
+    });
+  }
+
+  return response;
+}

--- a/lib/shared/api/server/response.ts
+++ b/lib/shared/api/server/response.ts
@@ -5,6 +5,36 @@ import type { ApiResponse } from "@/lib/shared/types";
 
 import { getSessionTokenFromCookies } from "./cookies";
 
+export function resolveApiPayload<T>(
+  payload: ApiResponse<T> | null | undefined,
+  status: number,
+  fallbackMessage: string,
+): ApiResponse<T> {
+  return (
+    payload ?? {
+      success: false,
+      error: {
+        message: fallbackMessage,
+        statusCode: status,
+      },
+    }
+  );
+}
+
+export function jsonApiResponse<T>({
+  status,
+  payload,
+  fallbackMessage,
+}: {
+  status: number;
+  payload?: ApiResponse<T> | null;
+  fallbackMessage: string;
+}) {
+  return NextResponse.json(resolveApiPayload(payload, status, fallbackMessage), {
+    status,
+  });
+}
+
 export async function proxyJson({
   path,
   method,
@@ -29,16 +59,11 @@ export async function proxyJson({
     fallbackMessage,
   });
 
-  return NextResponse.json(
-    (payload ?? {
-      success: false,
-      error: {
-        message: "응답을 처리할 수 없습니다.",
-        statusCode: status,
-      },
-    }) as ApiResponse<unknown>,
-    { status },
-  );
+  return jsonApiResponse({
+    status,
+    payload,
+    fallbackMessage: "응답을 처리할 수 없습니다.",
+  });
 }
 
 export function jsonError(message: string, status = 500) {

--- a/tests/unit/auth-session-response.test.ts
+++ b/tests/unit/auth-session-response.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+
+import { createSessionAuthResponse } from "@/lib/auth/server";
+
+const mockUser = {
+  id: "user-1",
+  email: "test@example.com",
+  nickname: "테스트유저",
+  sellerProfileId: "seller-1",
+  shopName: "테스트상점",
+};
+
+describe("createSessionAuthResponse", () => {
+  it("sets the session cookie when auth succeeds", () => {
+    const response = createSessionAuthResponse({
+      status: 200,
+      fallbackMessage: "로그인에 실패했습니다.",
+      payload: {
+        success: true,
+        data: {
+          user: mockUser,
+          accessToken: "access-token",
+          expiresIn: 3600,
+        },
+      },
+    });
+
+    const setCookieHeader = response.headers.get("set-cookie");
+
+    expect(response.status).toBe(200);
+    expect(setCookieHeader).toContain("cc_access_token=access-token");
+    expect(setCookieHeader).toContain("HttpOnly");
+    expect(setCookieHeader).toContain("Path=/");
+    expect(setCookieHeader).toContain("Max-Age=3600");
+  });
+
+  it("falls back without writing a cookie when payload is missing", async () => {
+    const response = createSessionAuthResponse({
+      status: 503,
+      fallbackMessage: "로그인에 실패했습니다.",
+      payload: undefined,
+    });
+
+    await expect(response.json()).resolves.toEqual({
+      success: false,
+      error: {
+        message: "로그인에 실패했습니다.",
+        statusCode: 503,
+      },
+    });
+    expect(response.headers.get("set-cookie")).toBeNull();
+  });
+});

--- a/tests/unit/route-error-panel.test.tsx
+++ b/tests/unit/route-error-panel.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { RouteErrorPanel } from "@/components/shared/ui";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("RouteErrorPanel", () => {
+  it("logs the error and retries through the provided handler", async () => {
+    const error = new Error("boom");
+    const reset = vi.fn();
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    render(
+      <RouteErrorPanel
+        error={error}
+        reset={reset}
+        eyebrow="오류 발생"
+        title="화면을 불러오지 못했습니다"
+        description="잠시 후 다시 시도해 주세요."
+      />,
+    );
+
+    await waitFor(() => {
+      expect(consoleErrorSpy).toHaveBeenCalledWith(error);
+    });
+
+    await userEvent.click(screen.getByRole("button", { name: "다시 시도" }));
+
+    expect(screen.getByText("오류 발생")).toBeVisible();
+    expect(screen.getByText("화면을 불러오지 못했습니다")).toBeVisible();
+    expect(reset).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- auth API route의 응답 fallback 생성과 세션 쿠키 처리 로직을 공통 헬퍼로 정리했습니다.
- `(auth)`와 `(store)`의 route error UI를 공용 `RouteErrorPanel`로 통합했습니다.
- 공통화된 동작을 검증하는 단위 테스트를 추가했습니다.

## Why
- 로그인/회원가입/로그아웃 route handler에 유사한 응답 생성 코드가 반복되고 있었습니다.
- route segment별 error 화면이 같은 로깅/재시도 패턴을 중복 구현하고 있었습니다.
- 공통화 포인트를 테스트로 고정해 이후 수정 비용을 낮추기 위함입니다.

## Validation
- `npm run lint`
- `npm test`


Closes #1